### PR TITLE
feat(ui): add stop dictation button to Result component (#3)

### DIFF
--- a/frontend/src/components/Result.jsx
+++ b/frontend/src/components/Result.jsx
@@ -1,8 +1,9 @@
 import ReactMarkdown from 'react-markdown';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 
 const Result = ({ data }) => {
   const utteranceRef = useRef(null);
+  const [readingAloud, setReadingAloud] = useState(false);
 
   const downloadSummary = () => {
     const element = document.createElement('a');
@@ -20,6 +21,15 @@ const Result = ({ data }) => {
     }
     utteranceRef.current = new window.SpeechSynthesisUtterance(data.summary);
     window.speechSynthesis.speak(utteranceRef.current);
+    setReadingAloud(true);
+  };
+
+  const stopDictation = () => {
+    if (utteranceRef.current) {
+      window.speechSynthesis.cancel();
+      utteranceRef.current = null;
+    }
+    setReadingAloud(false);
   };
 
   return (
@@ -35,7 +45,9 @@ const Result = ({ data }) => {
       </div>
       <div style={{ marginTop: 20, display: 'flex', gap: 16 }}>
         <button onClick={downloadSummary}>Download Summary</button>
-        <button onClick={readAloud}>🔊 Read Aloud</button>
+        <button onClick={readingAloud ? stopDictation : readAloud}>
+          {readingAloud ? '🔇 Stop Dictation' : '🔉 Read Aloud'}
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
This pull request introduces functionality for toggling text-to-speech dictation in the `Result` component. The changes include adding state management for tracking whether dictation is active, implementing a method to stop dictation, and updating the button behavior and label dynamically based on the dictation state.

Enhancements to text-to-speech functionality:

* [`frontend/src/components/Result.jsx`](diffhunk://#diff-b4c066c8830a3911e12abcfbc8da9d27f2db021804d39fc79116266d98620a63L2-R6): Added `useState` to manage the `readingAloud` state, which tracks whether dictation is active.
* [`frontend/src/components/Result.jsx`](diffhunk://#diff-b4c066c8830a3911e12abcfbc8da9d27f2db021804d39fc79116266d98620a63R24-R32): Implemented the `stopDictation` method to cancel ongoing speech synthesis and reset the `readingAloud` state.
* [`frontend/src/components/Result.jsx`](diffhunk://#diff-b4c066c8830a3911e12abcfbc8da9d27f2db021804d39fc79116266d98620a63L38-R50): Updated the text-to-speech button to toggle between starting and stopping dictation, with dynamic labels (`🔉 Read Aloud` and `🔇 Stop Dictation`) based on the `readingAloud` state.